### PR TITLE
new entity framework testing extension SetupDbSet method added

### DIFF
--- a/Trendyol.App.EntityFramework.Testing/MockExtensions.cs
+++ b/Trendyol.App.EntityFramework.Testing/MockExtensions.cs
@@ -31,6 +31,14 @@ namespace Trendyol.App.EntityFramework.Testing
             return mockDbSet;
         }
 
+        public static Mock<DbSet<TEntity>> SetupDbSet<TContext, TEntity>(this Mock<TContext> source,
+            Expression<Func<TContext, DbSet<TEntity>>> dbSetExp)
+            where TContext : DataContextBase<TContext>
+            where TEntity : class
+        {
+            return SetupDbSet(source, dbSetExp, new List<TEntity>());
+        }
+
         public static IEnumerable<TEntity> SetupDbSet<TContext, TEntity>(this IEnumerable<TEntity> source,
             Expression<Func<TContext, DbSet<TEntity>>> dbSetExp, Mock<TContext> mockDataContext)
             where TContext : DataContextBase<TContext>


### PR DESCRIPTION
Setup collections with extension method

`IEnumerable<PurchaseOrder> purchaseOrders = _fixture.Build<PurchaseOrder>().CreateMany(3).SetupDbSet(db=>db.PurchaseOrders, _mockDataContext);`

Setup single entity with extension method

`ReceivingOrder receivingOrder = _fixture.Build<ReceivingOrder>().Create().SetupDbSet(db => db.PurchaseOrders, _mockDataContext);`